### PR TITLE
Replace gradient placeholders with AuraSync logo image

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -219,7 +219,7 @@ const Auth: React.FC = () => {
       
       <div className="relative z-10 w-full max-w-md">
         <div className="text-center mb-8">
-          <div className="w-12 h-12 rounded-full bg-gradient-to-r from-primary to-accent mx-auto mb-4" />
+          <img src="https://i.ibb.co/4nDnvPR0/1.png" alt="AuraSync logo" className="w-12 h-12 rounded-full object-cover mx-auto mb-4" />
           <h1 className="text-3xl font-bold text-glow mb-2">AuraSync</h1>
           <p className="text-muted-foreground">Connect your emotions to music</p>
         </div>

--- a/src/pages/EmailConfirmation.tsx
+++ b/src/pages/EmailConfirmation.tsx
@@ -81,7 +81,7 @@ const EmailConfirmation: React.FC = () => {
       
       <div className="relative z-10 w-full max-w-md">
         <div className="text-center mb-8">
-          <div className="w-12 h-12 rounded-full bg-gradient-to-r from-primary to-accent mx-auto mb-4" />
+          <img src="https://i.ibb.co/4nDnvPR0/1.png" alt="AuraSync logo" className="w-12 h-12 rounded-full object-cover mx-auto mb-4" />
           <h1 className="text-3xl font-bold text-glow mb-2">AuraSync</h1>
           <p className="text-muted-foreground">Email Confirmation</p>
         </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -264,7 +264,7 @@ const Index = () => {
       <header className="relative z-10 p-6">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <div className="w-8 h-8 rounded-full bg-gradient-to-r from-primary to-accent" />
+            <img src="https://i.ibb.co/4nDnvPR0/1.png" alt="AuraSync logo" className="w-8 h-8 rounded-full object-cover" />
             <h1 className="text-2xl font-bold text-glow">AuraSync</h1>
           </div>
 


### PR DESCRIPTION
## Purpose
Replace the temporary gradient placeholder elements with the official AuraSync logo image across all authentication and main pages to establish consistent brand identity throughout the application.

## Code changes
- **Auth.tsx**: Replaced gradient div with logo image element using the provided URL
- **EmailConfirmation.tsx**: Updated placeholder to use actual AuraSync logo with proper alt text
- **Index.tsx**: Replaced header gradient placeholder with logo image
- Added consistent styling with `object-cover` class and appropriate alt text for accessibility
- Maintained existing size constraints (w-12 h-12 for auth pages, w-8 h-8 for header)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52283e5343644c7e9dce8dd22862e842/orbit-garden)

👀 [Preview Link](https://52283e5343644c7e9dce8dd22862e842-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52283e5343644c7e9dce8dd22862e842</projectId>-->
<!--<branchName>orbit-garden</branchName>-->