### PR TITLE
Add Spotify Premium plan gating for playlist features

### DIFF
--- a/src/components/MusicRecommendations.tsx
+++ b/src/components/MusicRecommendations.tsx
@@ -515,8 +515,9 @@ const MusicRecommendations: React.FC<MusicRecommendationsProps> = ({
             <Button
               size="sm"
               onClick={handleSave}
-              disabled={!isSpotifyConnected || playlists.length === 0}
+              disabled={!isSpotifyConnected || !isPremium || playlists.length === 0}
               className="rounded-full px-5 bg-primary text-primary-foreground shadow-md hover:shadow-lg transition-all w-full sm:w-auto"
+              title={!isSpotifyConnected ? 'Connect Spotify to save' : !isPremium ? 'Spotify Premium required to save/modify playlists' : undefined}
             >
               <Save className="w-4 h-4 mr-2" />
               Save

--- a/src/components/MusicRecommendations.tsx
+++ b/src/components/MusicRecommendations.tsx
@@ -134,6 +134,7 @@ const MusicRecommendations: React.FC<MusicRecommendationsProps> = ({
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [isSpotifyConnected, setIsSpotifyConnected] = useState(false);
+  const [isPremium, setIsPremium] = useState(false);
   const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistDisplay | null>(null);
 
   const [language, setLanguage] = useState<'all' | 'hindi' | 'bengali' | 'tamil' | 'telugu' | 'punjabi' | 'marathi'>('all');

--- a/src/components/MusicRecommendations.tsx
+++ b/src/components/MusicRecommendations.tsx
@@ -380,6 +380,14 @@ const MusicRecommendations: React.FC<MusicRecommendationsProps> = ({
       setIsSpotifyConnected(true);
       let currentAccessToken = profile.access_token as string;
 
+      // Determine plan for gating (premium vs free)
+      try {
+        const premium = await isSpotifyPremium(currentAccessToken);
+        setIsPremium(premium);
+      } catch {
+        setIsPremium(false);
+      }
+
       try {
         console.log('🎵 Fetching Spotify playlists...');
         const newPlaylists = await getSpotifyPlaylists(currentAccessToken);

--- a/src/components/MusicRecommendations.tsx
+++ b/src/components/MusicRecommendations.tsx
@@ -11,7 +11,8 @@ import {
   searchPlaylists,
   getEmotionGenre,
   refreshSpotifyToken,
-  SpotifyPlaylist
+  SpotifyPlaylist,
+  isSpotifyPremium
 } from '@/lib/spotify';
 
 export interface Track {

--- a/src/components/MusicRecommendations.tsx
+++ b/src/components/MusicRecommendations.tsx
@@ -605,6 +605,12 @@ const MusicRecommendations: React.FC<MusicRecommendationsProps> = ({
             Connect Spotify in your profile to get personalized playlist recommendations.
           </div>
         )}
+
+        {isSpotifyConnected && !isPremium && (
+          <div className="text-xs text-muted-foreground">
+            You’re on a free Spotify plan. You can browse playlists, but saving requires Spotify Premium.
+          </div>
+        )}
       </div>
     </Card>
   );

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -20,6 +20,7 @@ export interface SpotifyUser {
   display_name: string;
   email: string;
   images: Array<{ url: string; width: number; height: number }>;
+  product?: 'premium' | 'free' | 'open' | string;
 }
 
 export interface SpotifyTrack {
@@ -170,6 +171,25 @@ export const spotifyApiRequest = async (
 // Get current user profile
 export const getSpotifyProfile = async (accessToken: string): Promise<SpotifyUser> => {
   return spotifyApiRequest('/me', accessToken);
+};
+
+// Helper: determine if current user is Spotify Premium
+export const isSpotifyPremium = async (
+  accessToken?: string
+): Promise<boolean> => {
+  try {
+    if (accessToken) {
+      const me = await getSpotifyProfile(accessToken);
+      if (me?.product) {
+        localStorage.setItem('spotify_product', me.product);
+      }
+      return me?.product === 'premium';
+    }
+    const cached = localStorage.getItem('spotify_product');
+    return cached === 'premium';
+  } catch {
+    return false;
+  }
 };
 
 // Get recommendations based on seed data

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,7 +8,7 @@ import { Card } from '@/components/ui/card';
 import { Music, User, LogOut, ChevronDown, ArrowUp, BarChart3, History, Sparkles, Camera } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
-import { createPlaylist, addTracksToPlaylist } from '@/lib/spotify';
+import { createPlaylist, addTracksToPlaylist, isSpotifyPremium } from '@/lib/spotify';
 
 interface Track {
   id: string;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,6 +177,15 @@ const Index = () => {
       return;
     }
 
+    // Gate by plan: saving/modifying playlists requires Premium per Spotify policy
+    try {
+      const premium = await isSpotifyPremium(spotifyCredentials.access_token);
+      if (!premium) {
+        console.log('Saving playlists requires Spotify Premium. You can still browse and open playlists.');
+        return;
+      }
+    } catch {}
+
     try {
       const playlistName = `AuraSync - ${currentEmotion.charAt(0).toUpperCase() + currentEmotion.slice(1)} Vibes`;
       const playlistDescription = `AI-generated playlist for your ${currentEmotion} mood. Created by AuraSync on ${new Date().toLocaleDateString()}`;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -152,6 +152,7 @@ const Profile: React.FC = () => {
         console.error('Error disconnecting Spotify:', error);
         toast.error('Failed to disconnect Spotify');
       } else {
+        try { localStorage.removeItem('spotify_product'); } catch {}
         setProfile(prev => prev ? {
           ...prev,
           spotify_user_id: null,

--- a/src/pages/SpotifyCallback.tsx
+++ b/src/pages/SpotifyCallback.tsx
@@ -68,6 +68,10 @@ const SpotifyCallback: React.FC = () => {
 
         // Get user profile from Spotify
         const spotifyProfile = await getSpotifyProfile(tokenData.access_token);
+        // Cache plan locally for gating (no DB schema changes needed)
+        if (spotifyProfile?.product) {
+          localStorage.setItem('spotify_product', spotifyProfile.product);
+        }
 
         // Update user profile with Spotify data
         const { error: updateError } = await supabase


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements plan-based access control for Spotify features. Users with free Spotify accounts can browse and view playlists, while premium users get full access to save and modify playlists. This addresses Spotify Web API authentication issues and aligns with Spotify's API policies while maintaining existing functionality for all other features.

## Code changes

- **Added `isSpotifyPremium()` function** in `spotify.ts` to check user's subscription plan via Spotify API
- **Enhanced user state management** with `isPremium` state tracking in `MusicRecommendations` component
- **Implemented feature gating** for save/modify playlist buttons - disabled for free users with helpful tooltips
- **Added plan detection** during Spotify authentication flow with local storage caching
- **Updated UI feedback** to inform free users about premium-only features
- **Added cleanup** for cached plan data when disconnecting Spotify account

The changes preserve all existing functionality while adding appropriate access controls based on Spotify subscription tier.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52283e5343644c7e9dce8dd22862e842/neon-oasis)

👀 [Preview Link](https://52283e5343644c7e9dce8dd22862e842-neon-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52283e5343644c7e9dce8dd22862e842</projectId>-->
<!--<branchName>neon-oasis</branchName>-->